### PR TITLE
Fixes #4398 Refactor ForemanHooks to be usable from a cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,23 @@ You can also specify a second argument to foreman_reports_upload which is a numb
 - 1 (default) for reporter based on more detailed ResourceReporter
 - 2 not so verbose based just on run_status, actually just counts applied resources
 
+Alternatively you can call the handler from the config script:
+chef_gem 'chef_handler_foreman'
+require 'chef_handler_foreman'
+
+```ruby
+chef_handler "ChefHandlerForeman::ForemanReporting" do
+  arguments [
+    :url => "https://foreman_url",
+    :foreman_ssl_cert => "/path/to/ssl.crt",
+    :foreman_ssl_key => "/path/to/ssl.key",
+    :client_key => "/path/to/client.key"
+  ]
+  source "chef_handler_foreman/foreman_reporting"
+  action :enable
+end
+```
+
 ## Chef 10 support
 
 Chef 10 is generally supported from version 0.0.6 and above. However you must set

--- a/lib/chef_handler_foreman/foreman_facts.rb
+++ b/lib/chef_handler_foreman/foreman_facts.rb
@@ -12,10 +12,16 @@
 #along with this program.  If not, see <http://www.gnu.org/licenses/>
 
 require 'chef/handler'
+require 'chef_handler_foreman/foreman_uploader'
 
 module ChefHandlerForeman
   class ForemanFacts < Chef::Handler
     attr_accessor :uploader
+    attr_reader :config
+
+    def initialize(config=nil)
+      @uploader = ForemanUploader.new(config) unless config.nil?
+    end
 
     def report
       send_attributes(prepare_facts)

--- a/lib/chef_handler_foreman/foreman_reporting.rb
+++ b/lib/chef_handler_foreman/foreman_reporting.rb
@@ -12,10 +12,16 @@
 #along with this program.  If not, see <http://www.gnu.org/licenses/>
 
 require 'chef/handler'
+require 'chef_handler_foreman/foreman_uploader'
 
 module ChefHandlerForeman
   class ForemanReporting < ::Chef::Handler
     attr_accessor :uploader
+    attr_reader :config
+
+    def initialize(config=nil)
+      @uploader = ForemanUploader.new(config) unless config.nil?
+    end
 
     def report
       report                   = { 'host' => node.fqdn, 'reported_at' => Time.now.utc.to_s }


### PR DESCRIPTION
This enables foreman reporting from inside a recipe.

Example:

``` ruby
require 'chef_handler_foreman'

chef_handler "ChefHandlerForeman::ForemanReporting" do
  arguments [
    :url => "http://foreman.lan",
    :foreman_ssl_cert => "/path/to/ssl.crt",
    :foreman_ssl_key => "/path/to/ssl.key",
    :client_key => "/path/to/client.key"
  ]
  source "chef_handler_foreman/foreman_reporting"
  action :enable
end
```
