### PR TITLE
Fix require path

### DIFF
--- a/lib/chef_handler_foreman.rb
+++ b/lib/chef_handler_foreman.rb
@@ -1,5 +1,5 @@
-require "chef_handler_foreman/version"
+require "#{File.dirname(__FILE__)}/chef_handler_foreman/version"
 require 'chef'
-require 'chef_handler_foreman/foreman_hooks'
+require "#{File.dirname(__FILE__)}/chef_handler_foreman/foreman_hooks"
 
 Chef::Config.send :extend, ChefHandlerForeman::ForemanHooks

--- a/lib/chef_handler_foreman/foreman_hooks.rb
+++ b/lib/chef_handler_foreman/foreman_hooks.rb
@@ -1,12 +1,12 @@
-require 'chef_handler_foreman/foreman_facts'
-require 'chef_handler_foreman/foreman_reporting'
+require "#{File.dirname(__FILE__)}/foreman_facts"
+require "#{File.dirname(__FILE__)}/foreman_reporting"
 
 # this reporter is supported in chef 11 or later
 unless Gem::Version.new(Chef::VERSION) < Gem::Version.new('11.0.0')
-  require 'chef_handler_foreman/foreman_resource_reporter'
+  require "#{File.dirname(__FILE__)}/foreman_resource_reporter"
 end
 
-require 'chef_handler_foreman/foreman_uploader'
+require "#{File.dirname(__FILE__)}/foreman_uploader"
 
 module ChefHandlerForeman
   module ForemanHooks


### PR DESCRIPTION
I'm currently using chef-client omnibus packages and I really want to avoid to deploy a chef_gem so I deploy all my chef-client handlers in /var/chef/handlers directory.
When I do that, I get some LoadError:
`FATAL: Configuration error LoadError: cannot load such file -- chef_handler_foreman/version`

This PR aims to fix that problem
