### PR TITLE
Force lower-case node names

### DIFF
--- a/lib/chef_handler_foreman/foreman_facts.rb
+++ b/lib/chef_handler_foreman/foreman_facts.rb
@@ -41,7 +41,7 @@ module ChefHandlerForeman
       release ||= node.platform_version
 
       # operatingsystem and operatingsystemrelase are not needed since foreman_chef 0.1.3
-      { :name  => node.name,
+      { :name  => node.name.downcase,
         :facts => plain_attributes.merge({
                                              :environment            => node.chef_environment,
                                              :chef_node_name         => node.name,

--- a/lib/chef_handler_foreman/foreman_resource_reporter.rb
+++ b/lib/chef_handler_foreman/foreman_resource_reporter.rb
@@ -91,7 +91,7 @@ module ChefHandlerForeman
 
     def prepare_run_data
       run_data                = {}
-      run_data["host"]        = node_name
+      run_data["host"]        = node_name.downcase
       run_data["reported_at"] = end_time.to_s
       run_data["status"]      = resources_per_status
 


### PR DESCRIPTION
Fixes a bug when submitting a node with a capitalized node name (e.g. HOSTNAME.domain.local). The Foreman downcases node names when creating a new node from a fact import, but does not follow the same logic when creating a node from a report import. This leads to two nodes being created with one containing the reports, and the other containing the facts. 

See the following bug issue:

http://projects.theforeman.org/issues/12185