### PR TITLE
Fixed warning "Deprecated features used!"

### DIFF
--- a/lib/chef_handler_foreman/foreman_facts.rb
+++ b/lib/chef_handler_foreman/foreman_facts.rb
@@ -41,10 +41,10 @@ module ChefHandlerForeman
       release ||= node['platform_version']
 
       # operatingsystem and operatingsystemrelase are not needed since foreman_chef 0.1.3
-      { :name  => node['fqdn'],
+      { :name  => node.name.downcase,
         :facts => plain_attributes.merge({
-                                             :environment            => node['chef_environment'],
-                                             :chef_node_name         => node['fqdn'],
+                                             :environment            => node.chef_environment,
+                                             :chef_node_name         => node.name,
                                              :operatingsystem        => normalize(os),
                                              :operatingsystemrelease => release,
                                              :_timestamp             => Time.now,
@@ -112,7 +112,7 @@ module ChefHandlerForeman
         if uploader
           Chef::Log.info 'Sending attributes to foreman'
           Chef::Log.debug attributes.inspect
-          uploader.foreman_request('/api/hosts/facts', attributes, node['fqdn'])
+          uploader.foreman_request('/api/hosts/facts', attributes, node.name)
         else
           Chef::Log.error "No uploader registered for foreman facts, skipping facts upload"
         end

--- a/lib/chef_handler_foreman/foreman_facts.rb
+++ b/lib/chef_handler_foreman/foreman_facts.rb
@@ -34,17 +34,17 @@ module ChefHandlerForeman
 
       os, release = nil
       if node.respond_to?(:lsb)
-        os = node.lsb[:id]
-        release = node.lsb[:release]
+        os = node['lsb']['id']
+        release = node['lsb']['release']
       end
-      os ||= node.platform
-      release ||= node.platform_version
+      os ||= node['platform']
+      release ||= node['platform_version']
 
       # operatingsystem and operatingsystemrelase are not needed since foreman_chef 0.1.3
-      { :name  => node.name.downcase,
+      { :name  => node['fqdn'],
         :facts => plain_attributes.merge({
-                                             :environment            => node.chef_environment,
-                                             :chef_node_name         => node.name,
+                                             :environment            => node['chef_environment'],
+                                             :chef_node_name         => node['fqdn'],
                                              :operatingsystem        => normalize(os),
                                              :operatingsystemrelease => release,
                                              :_timestamp             => Time.now,
@@ -53,7 +53,7 @@ module ChefHandlerForeman
       }
     end
 
-    # if node.lsb[:id] fails and we use platform instead, normalize os names
+    # if node['lsb']['id'] fails and we use platform instead, normalize os names
     def normalize(os)
       case os
       when 'redhat'
@@ -112,7 +112,7 @@ module ChefHandlerForeman
         if uploader
           Chef::Log.info 'Sending attributes to foreman'
           Chef::Log.debug attributes.inspect
-          uploader.foreman_request('/api/hosts/facts', attributes, node.name)
+          uploader.foreman_request('/api/hosts/facts', attributes, node['fqdn'])
         else
           Chef::Log.error "No uploader registered for foreman facts, skipping facts upload"
         end

--- a/lib/chef_handler_foreman/foreman_reporting.rb
+++ b/lib/chef_handler_foreman/foreman_reporting.rb
@@ -80,7 +80,7 @@ module ChefHandlerForeman
 
     def send_report(report)
       if uploader
-        uploader.foreman_request('/api/reports', report, node['fqdn'])
+        uploader.foreman_request('/api/reports', report, node.name)
       else
         Chef::Log.error "No uploader registered for foreman reporting, skipping report upload"
       end

--- a/lib/chef_handler_foreman/foreman_reporting.rb
+++ b/lib/chef_handler_foreman/foreman_reporting.rb
@@ -18,7 +18,7 @@ module ChefHandlerForeman
     attr_accessor :uploader
 
     def report
-      report                   = { 'host' => node.fqdn.downcase, 'reported_at' => Time.now.utc.to_s }
+      report                   = { 'host' => node['fqdn'].downcase, 'reported_at' => Time.now.utc.to_s }
       report_status            = Hash.new(0)
 
 
@@ -80,7 +80,7 @@ module ChefHandlerForeman
 
     def send_report(report)
       if uploader
-        uploader.foreman_request('/api/reports', report, node.name)
+        uploader.foreman_request('/api/reports', report, node['fqdn'])
       else
         Chef::Log.error "No uploader registered for foreman reporting, skipping report upload"
       end


### PR DESCRIPTION
Method access to node attributes (node.foo.bar) is deprecated and
will be removed in Chef 13.
Recommended syntax is (node["foo"]["bar"]).
