### PR TITLE
Add a chef-client cookbook compatible foreman url option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ In /etc/chef/client.rb:
 require 'chef_handler_foreman'
 # here you can specify your connection options
 foreman_server_options  :url => 'http://your.server/foreman'
+# Or another option to set URL if using chef-client cookbook config option
+foreman_server_url 'http://foreman.domain.com'
 # add following line if you want to upload node attributes (facts in Foreman language)
 foreman_facts_upload    true
 ## Facts whitelist / blacklisting
@@ -64,3 +66,4 @@ attributes known to work in a large scale production environment.
 
 Note that the order of config options matter. Blacklist/whitelist must be below foreman_facts_upload
 line.
+

--- a/README.md
+++ b/README.md
@@ -37,6 +37,34 @@ foreman_reports_upload  true
 reports_log_level       "notice"
 ```
 
+### Using Chef-Client Cookbook
+
+You can utilize the [Chef-Client](https://github.com/chef-cookbooks/chef-client) Cookbook to setup your client.rb
+
+With a Role
+
+```json
+"chef_client": {
+  "chef_server_url": "https://chef.domain.com",
+  "config": {
+    "foreman_server_url": "https://foreman.domain.com",
+    "foreman_facts_upload": true,
+    "foreman_reports_upload": true,
+    "reports_log_level": "notice"
+  }
+}
+```
+
+With attributes
+
+```ruby
+node['chef_client']['config']['foreman_server_url'] = 'https://foreman.domain.com'
+node['chef_client']['config']['foreman_facts_upload'] = true
+node['chef_client']['config']['foreman_reports_upload'] = true
+node['chef_client']['config']['reports_log_level'] = 'notice'
+```
+
+
 You can also specify a second argument to foreman_reports_upload which is a number:
 - 1 (default) for reporter based on more detailed ResourceReporter
 - 2 not so verbose based just on run_status, actually just counts applied resources

--- a/lib/chef_handler_foreman/foreman_hooks.rb
+++ b/lib/chef_handler_foreman/foreman_hooks.rb
@@ -10,9 +10,16 @@ require "#{File.dirname(__FILE__)}/foreman_uploader"
 
 module ChefHandlerForeman
   module ForemanHooks
+
+    # Provide a chef-client cookbook friendly option
+    def foreman_server_url(url)
+      foreman_server_options(:url => url)
+    end
+
     # {:url => '', ...}
-    def foreman_server_options(options)
-      options = { :client_key => client_key || '/etc/chef/client.pem' }.merge(options)
+    def foreman_server_options(options={})
+      options[:client_key] = '/etc/chef/client.pem' unless options[:client_key]
+      raise "No Foreman URL! Please provide a URL" unless options[:url]
       @foreman_uploader = ForemanUploader.new(options)
       # set uploader if handlers are already created
       @foreman_facts_handler.uploader = @foreman_uploader if @foreman_facts_handler


### PR DESCRIPTION
Unfortunately you can't pass a hash into the chef-client cookbook for adding items to the client.rb.

- So I have added a separate method (optional) method to allow setting via just `foreman_server_url 'http://foreman.domain.com`

- I also added a catch in-case the url is not present (as I noticed it fails silently if still triggered without a url, even with debug level logging)

- I added documentation on how to utilize the chef-client cookbook to setup the foreman options in the client.rb.

- Changed the conditionals around client_key to allow cleaner code (and to make rubocop a little less aggravated)